### PR TITLE
Added reproducible build infrastructure using Nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ cabal.sandbox.config
 .stack-work/
 cabal.project.local
 .HTF/
+result*

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,1 @@
+(import ./nix/main.nix {}).haskellPackages."virtual-piano"

--- a/nix/fetch-nixpkgs.nix
+++ b/nix/fetch-nixpkgs.nix
@@ -1,0 +1,51 @@
+{ rev                             # The Git revision of nixpkgs to fetch
+, sha256                          # The SHA256 of the downloaded data
+, system ? builtins.currentSystem # This is overridable if necessary
+}:
+
+with {
+  ifThenElse = { bool, thenValue, elseValue }: (
+    if bool then thenValue else elseValue);
+};
+
+ifThenElse {
+  bool = (0 <= builtins.compareVersions builtins.nixVersion "1.12");
+
+  # In Nix 1.12, we can just give a `sha256` to `builtins.fetchTarball`.
+  thenValue = (
+    builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+      inherit sha256;
+    });
+
+  # This hack should at least work for Nix 1.11
+  elseValue = (
+    (rec {
+      tarball = import <nix/fetchurl.nix> {
+        url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+        inherit sha256;
+      };
+
+      builtin-paths = import <nix/config.nix>;
+      
+      script = builtins.toFile "nixpkgs-unpacker" ''
+        "$coreutils/mkdir" "$out"
+        cd "$out"
+        "$gzip" --decompress < "$tarball" | "$tar" -x --strip-components=1
+      '';
+
+      nixpkgs = builtins.derivation {
+        name = "nixpkgs-${builtins.substring 0 6 rev}";
+
+        builder = builtins.storePath builtin-paths.shell;
+
+        args = [ script ];
+
+        inherit tarball system;
+
+        tar       = builtins.storePath builtin-paths.tar;
+        gzip      = builtins.storePath builtin-paths.gzip;
+        coreutils = builtins.storePath builtin-paths.coreutils;
+      };
+    }).nixpkgs);
+}

--- a/nix/main.nix
+++ b/nix/main.nix
@@ -1,0 +1,38 @@
+{ system ? builtins.currentSystem }:
+
+rec {
+  fetchNixpkgs = import ./fetch-nixpkgs.nix;
+
+  nixpkgs = fetchNixpkgs {
+    rev    = "19879836d10f64a10658d1e2a84fc54b090e2087";
+    sha256 = "0x7xa9xgdraqxhhz548nng5gcs37193zvq8v9ngbqd2lzn2dm4hd";
+    inherit system;
+  };
+  
+  pkgs = import nixpkgs {
+    config = { allowUnfree = true; overrides = []; };
+    inherit system;
+  };
+
+  filterPath = path: (
+    with {
+      sf = name: type: let bn = baseNameOf (toString name); in !(
+        (type == "directory" && (bn == ".git"))
+        || pkgs.lib.hasSuffix "~" bn
+        || pkgs.lib.hasSuffix ".o" bn
+        || pkgs.lib.hasSuffix ".so" bn
+        || pkgs.lib.hasSuffix ".nix" bn
+        || (type == "symlink" && pkgs.lib.hasPrefix "result" bn)
+      );
+    };
+    builtins.filterSource sf path);
+
+  source = filterPath ./..;
+  
+  haskellPackages = pkgs.haskellPackages.override {
+    overrides = self: super: {
+      PortMidi      = self.callHackage "PortMidi" "0.1.5.2" {};
+      virtual-piano = self.callCabal2nix "virtual-piano" source {};
+    };
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,2 @@
+let drv = import ./default.nix;
+in if builtins.getEnv "IN_NIX_SHELL" != "" then drv.env else drv


### PR DESCRIPTION
You can now build this project reproducibly by running `nix-build` in the root directory.
You can also enter a shell with all the required dependencies by running `nix-shell`.